### PR TITLE
80 docs bootstrap community documentation baseline tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Report broken behavior with enough context to reproduce it.
+title: "[bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        Please describe the issue in a way that a new contributor can understand and reproduce.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: The app crashes when...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this matter to the user or contributor?
+      placeholder: I was trying to...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the smallest reliable sequence.
+      placeholder: |
+        1. Run...
+        2. Open...
+        3. Press...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The player should...
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Instead, the app...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, terminal, Go version, FFmpeg availability, anything relevant.
+      placeholder: Windows 11, PowerShell, Go 1.25.5, ffplay installed
+  - type: textarea
+    id: starting_points
+    attributes:
+      label: Possible starting points
+      description: Optional. Add files or packages if you already know where the bug may live.
+      placeholder: player/player.go, tui/update.go
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty guess
+      description: Optional. Helps maintainers shape the issue for newcomers.
+      options:
+        - easy
+        - medium
+        - hard
+        - unknown
+    validations:
+      required: false
+  - type: dropdown
+    id: estimate
+    attributes:
+      label: Time estimate guess
+      description: Optional. Choose the smallest realistic estimate.
+      options:
+        - less than 1 hour
+        - 1-2 hours
+        - half day
+        - 1 day
+        - more than 1 day
+        - unknown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support guide
+    url: https://github.com/samuaks/playmusic/blob/master/SUPPORT.md
+    about: Read where to ask for help and what response times to expect.
+  - name: Security policy
+    url: https://github.com/samuaks/playmusic/blob/master/SECURITY.md
+    about: Read how to report possible security issues without posting sensitive details publicly.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,87 @@
+name: Development task
+description: Create a contributor-friendly development task with clear scope.
+title: "[task]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for planned work that should be understandable to a first-time contributor.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this work matter to the project or user?
+      placeholder: This matters because...
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What is wrong or missing today?
+      placeholder: Right now...
+    validations:
+      required: true
+  - type: textarea
+    id: scope_in
+    attributes:
+      label: In scope
+      description: Describe what should be included.
+      placeholder: |
+        - update...
+        - add...
+        - verify...
+    validations:
+      required: true
+  - type: textarea
+    id: scope_out
+    attributes:
+      label: Out of scope
+      description: Explicitly state what should not be done in this issue.
+      placeholder: |
+        - do not refactor...
+        - do not redesign...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Write checkable outcomes.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: starting_points
+    attributes:
+      label: Starting points
+      description: Files, packages, tests, or PRs worth reading first.
+      placeholder: main.go, library/scan.go, tui/update.go
+    validations:
+      required: true
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty
+      options:
+        - easy
+        - medium
+        - hard
+    validations:
+      required: true
+  - type: dropdown
+    id: estimate
+    attributes:
+      label: Estimated time
+      options:
+        - less than 1 hour
+        - 1-2 hours
+        - half day
+        - 1 day
+        - more than 1 day
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+What changed?
+
+## Why
+
+Why does this change matter?
+
+## Verification
+
+What did you run or check?
+
+- [ ] `go test ./...`
+- [ ] relevant manual verification
+- [ ] docs updated if behavior changed
+
+## Scope
+
+What is intentionally out of scope?
+
+## Notes For Reviewers
+
+Anything reviewers should look at first?

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ secrets
 # Dependency directories (remove the comment below to include it)
 
 # vendor/
+docs/ru/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code Of Conduct
+
+## Our Goal
+
+PlayMusic is a learning-friendly open-source project. We want contributors, especially students and first-time collaborators, to feel safe asking questions, sharing drafts, and learning in public.
+
+## Expected Behavior
+
+- Be respectful in issues, pull requests, and review comments.
+- Assume good intent and ask clarifying questions before escalating.
+- Give feedback about code and behavior, not about a person's worth.
+- Help newer contributors understand context instead of testing whether they already know it.
+- Keep collaboration practical, kind, and specific.
+
+## Unacceptable Behavior
+
+- Harassment, insults, or personal attacks.
+- Belittling beginner questions or mocking mistakes.
+- Discriminatory language or exclusionary behavior.
+- Repeatedly derailing technical discussions into personal conflict.
+- Publishing private or sensitive information without permission.
+
+## Scope
+
+This code of conduct applies to project spaces, including:
+
+- GitHub issues and pull requests;
+- code review discussions;
+- project chat or onboarding spaces created for this repository.
+
+## Reporting
+
+If you experience or witness behavior that breaks this code of conduct:
+
+- contact the maintainers using the guidance in [SUPPORT.md](SUPPORT.md);
+- if a private channel is not available yet, ask for one without posting sensitive details publicly.
+
+Reports should be handled respectfully and in good faith.
+
+## Enforcement
+
+Maintainers may remove comments, pause discussions, or restrict participation when needed to protect the project space and its contributors.
+
+The goal of enforcement is to restore a safe, productive environment, not to create fear.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing To PlayMusic
+
+Thanks for contributing to PlayMusic.
+
+This project is intentionally beginner-friendly. Small pull requests, focused tests, and scoped bug fixes are all valuable contributions.
+
+Project language is English. Please use English in issues, pull requests, review comments, and repository documentation.
+
+## Before You Start
+
+- Read [README.md](README.md) for the project goal and quick start.
+- Read [docs/onboarding.md](docs/onboarding.md) if this is your first contribution here.
+- Read [SUPPORT.md](SUPPORT.md) if you are unsure where to ask for help.
+
+## Good First Contributions
+
+These are great first PRs:
+- add or improve a focused test in `library`, `tui`, or `player`;
+- improve error messages, help text, or TUI copy;
+- fix a well-scoped bug with a clear reproduction path;
+- rewrite or clarify an issue so a new contributor can understand it.
+
+These are usually not ideal first PRs:
+- wide refactors across several packages;
+- release workflow changes without prior discussion;
+- exploratory work around unstable online or radio flows;
+- "clean up everything" changes with no clear acceptance criteria.
+
+## Local Setup
+
+Clone the repository and verify that the code builds and tests on your machine:
+
+```bash
+go test ./...
+go run .
+```
+
+If you want extended format support or `.mp4` handoff, install FFmpeg so `ffplay` is available in your `PATH`.
+
+On the first app run, PlayMusic may also need internet access to resolve or install its `yt-dlp` helper binary.
+
+## How To Pick A Task
+
+- Start with issues labeled `good first issue` or clearly scoped `bug` tasks.
+- If the issue is vague, comment first and ask for scope confirmation before coding.
+- If you are new, prefer tasks that touch one package and have obvious verification steps.
+
+For more guidance, read [docs/workflow.md](docs/workflow.md).
+
+## How To Create An Issue
+
+If the work does not already have an issue, create one before writing code.
+
+Recommended flow:
+
+1. search open issues first to avoid duplicates;
+2. choose the matching GitHub template:
+   `Bug report` for broken behavior or `Development task` for planned work;
+3. write a short, specific title;
+4. fill in the template so a new contributor could understand the task without private context;
+5. only then use `Create a branch` from that issue.
+
+When you open an issue, keep it to one problem or one outcome.
+
+## Issue-First Workflow
+
+For implementation work, the expected flow is:
+
+1. create or confirm the GitHub issue;
+2. make sure the issue title is short and descriptive;
+3. use GitHub's `Create a branch` action from that issue;
+4. open the pull request back to the same issue context.
+
+Because the branch is created from the issue, issue naming matters.
+
+Good issue titles are:
+
+- short enough to scan quickly in the issue list;
+- specific about the problem or missing behavior;
+- written in clear English without internal shorthand.
+
+Examples:
+
+- `Fix search hint after leaving search mode`
+- `Keep background scan items in arrival order`
+- `Handle missing ffplay more clearly`
+
+Avoid issue titles like:
+
+- `Fix stuff`
+- `UI bug`
+- `Refactor`
+
+If GitHub generates the branch from the issue, keep that default unless there is a strong reason to change it manually.
+
+## Coding Expectations
+
+- Keep changes focused and easy to review.
+- Match the existing style of the package you touch.
+- Run `gofmt` on modified Go files.
+- Add or update tests when behavior changes.
+- Update docs when user-facing behavior changes.
+- Do not document experimental features as stable.
+
+## Pull Request Checklist
+
+Before opening a PR, make sure you can say "yes" to most of these:
+
+- I can explain the problem in one or two sentences.
+- I kept the scope intentionally small.
+- I ran `go test ./...` locally, or I explained why I could not.
+- I manually checked the relevant user flow if the change affects behavior.
+- I updated docs or help text if the change is user-facing.
+- I described what is intentionally out of scope.
+
+## Commit Messages
+
+There is no strict format requirement, but clear commit messages help reviewers.
+
+Prefer short imperative messages such as:
+
+- `fix tui search hint after focus change`
+- `test library scan skips missing dirs`
+- `fix player status text after track switch`
+
+## Reviews And Merge Flow
+
+- Open the PR early if you want feedback on direction.
+- Keep discussion in the PR so future contributors can learn from it.
+- Expect review comments to improve clarity, scope, and maintainability, not to gatekeep.
+- If something is unclear, ask directly in the PR instead of guessing.
+
+## Reporting Blockers
+
+If you are blocked:
+
+1. Explain what you tried.
+2. Mention the file or issue you were working on.
+3. Say what kind of help you need: scope, code direction, test help, or review.
+
+Use [SUPPORT.md](SUPPORT.md) for the right channel.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,28 @@ Project language is English. Please use English in issues, pull requests, review
 - Read [docs/onboarding.md](docs/onboarding.md) if this is your first contribution here.
 - Read [SUPPORT.md](SUPPORT.md) if you are unsure where to ask for help.
 
+## CLI Repository vs Desktop Application
+
+This repository is the CLI/TUI version of PlayMusic. It runs in the terminal and is mostly Go code.
+
+The related desktop application is [samuaks/musical-palm-tree](https://github.com/samuaks/musical-palm-tree). It opens in a separate native window and is built with Tauri, React, and Rust.
+
+For a longer comparison, read [docs/related-projects.md](docs/related-projects.md).
+
+Use this repository for:
+
+- terminal controls, TUI behavior, and local CLI playback;
+- Go packages such as `library`, `tui`, `player`, `decoder`, `ffmpeg`, and `yt_dlp`;
+- CLI contributor documentation, tests, and GitHub workflow improvements.
+
+Use `samuaks/musical-palm-tree` for:
+
+- desktop-window application behavior;
+- React UI, waveform player UI, video viewport, and library view changes;
+- Tauri/Rust scanner, waveform generation, IPC, and native app packaging.
+
+If a task mentions the "application" part of PlayMusic, check whether it means the separate desktop app before opening an issue or PR here.
+
 ## Good First Contributions
 
 These are great first PRs:
@@ -26,6 +48,17 @@ These are usually not ideal first PRs:
 - exploratory work around unstable online or radio flows;
 - "clean up everything" changes with no clear acceptance criteria.
 
+If you are looking for a first task, prefer issues that are already labeled `good first issue`, `bug`, or have a clearly small scope. A good first issue should be understandable from the issue body without private context.
+
+Before starting, check that the issue has:
+
+- a clear problem or desired outcome;
+- small scope, ideally one package or one user flow;
+- acceptance criteria or obvious verification steps;
+- starting points such as files, packages, or tests to read first.
+
+If an issue is missing those details, improving the issue description is a good first contribution too. Ask a short clarifying question or propose a rewritten issue body before coding.
+
 ## Local Setup
 
 Clone the repository and verify that the code builds and tests on your machine:
@@ -34,6 +67,16 @@ Clone the repository and verify that the code builds and tests on your machine:
 go test ./...
 go run .
 ```
+
+For more detailed test output, add `-v`:
+
+```bash
+go test -v ./...
+go test -v ./library
+go test -run TestName -v ./tui
+```
+
+Use `go test ./...` as the default pre-PR check. Use `-v` when you want to see each test name, debug a failure, or show clearer verification notes in a pull request.
 
 If you want extended format support or `.mp4` handoff, install FFmpeg so `ffplay` is available in your `PATH`.
 
@@ -61,6 +104,22 @@ Recommended flow:
 5. only then use `Create a branch` from that issue.
 
 When you open an issue, keep it to one problem or one outcome.
+
+## Issue Size And Estimates
+
+Issue estimates are rough planning hints, not promises.
+
+Use small estimates for first-time contributor work:
+
+| Estimate | Meaning |
+| --- | --- |
+| `1 point` | copy, docs, one focused test, or a tiny behavior fix |
+| `2 points` | small change in one package with clear verification |
+| `3 points` | one-package behavior change that needs tests and manual checking |
+| `5 points` | larger work, multiple files, or unclear edge cases |
+| `8 points` | split this before treating it as a first contribution |
+
+If a task feels bigger than its estimate, stop and comment with what you found. Splitting the issue is better than growing a first PR until it becomes hard to review.
 
 ## Issue-First Workflow
 
@@ -93,6 +152,21 @@ Avoid issue titles like:
 
 If GitHub generates the branch from the issue, keep that default unless there is a strong reason to change it manually.
 
+## Fork Workflow
+
+If you do not have write access to this repository, use a fork.
+
+Recommended fork flow:
+
+1. fork `samuaks/playmusic` on GitHub;
+2. clone your fork locally;
+3. create a branch for one issue;
+4. make the change and verify it;
+5. push the branch to your fork;
+6. open a pull request back to `samuaks/playmusic`.
+
+If you are using GitHub's issue page, you may still use the issue title as your branch name. Keep the branch short and specific, for example `fix-search-hint` or `test-library-scan-missing-dir`.
+
 ## Coding Expectations
 
 - Keep changes focused and easy to review.
@@ -117,11 +191,28 @@ Before opening a PR, make sure you can say "yes" to most of these:
 
 There is no strict format requirement, but clear commit messages help reviewers.
 
+Clear means that a reviewer can understand the change without opening the diff first. Prefer a short imperative sentence that names the area and the outcome.
+
 Prefer short imperative messages such as:
 
 - `fix tui search hint after focus change`
 - `test library scan skips missing dirs`
 - `fix player status text after track switch`
+
+Good commit messages usually:
+
+- start with the action: `fix`, `test`, `docs`, `add`, `update`, or `remove`;
+- mention the package or user-facing area when helpful;
+- describe one meaningful change, not a whole work session;
+- avoid private shorthand that only the author understands.
+
+Avoid vague messages such as:
+
+- `fix`
+- `changes`
+- `update`
+- `work in progress`
+- `stuff`
 
 ## Reviews And Merge Flow
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PlayMusic contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,130 +1,113 @@
-# Go Media Player
+# PlayMusic
 
-A modular command-line media player written in Go. Uses [beep](https://github.com/gopxl/beep) for native audio playback with optional FFmpeg support for extended format compatibility.
+PlayMusic is a terminal media player written in Go and a student-friendly open-source playground for learning collaborative development.
 
-## Features
-- Plays audio files from a `Media` directory automatically
-- Native support for mp3, flac, wav, and ogg without any external dependencies
-- Extended format support (m4a, mp4, aac, opus) when FFmpeg is installed
-- Displays track listing with durations on startup
-- Modular architecture split across `library`, `player`, and `colors` packages
-- Search and stream songs from the web
+The project is meant to be useful in two ways:
+- as a real application you can run, inspect, and improve;
+- as a safe place for Hive students/sprinters and first-time contributors to practice reading code, discussing scope, writing tests, and opening pull requests.
 
-## Supported Formats
+Project language is English for repository docs, issues, pull requests, and other contributor-facing materials.
 
-| Format     | Requires FFmpeg |
-|------------|----------------|
-| .mp3       | No |
-| .flac      | No |
-| .wav       | No |
-| .ogg       | No |
-| .m4a       | Yes |
-| .mp4       | Yes |
-| .aac       | Yes |
-| .opus      | Yes |
-| streaming  | Yes |
+## Start Here
 
+- Want to run the app quickly? Start with [Quick Start](#quick-start).
+- Want to make your first contribution? Read [docs/onboarding.md](docs/onboarding.md).
+- Need contribution rules? Read [CONTRIBUTING.md](CONTRIBUTING.md).
+- Need help or response expectations? Read [SUPPORT.md](SUPPORT.md).
 
-## Roadmap
+## What You Can Do In Your First Hour
 
-| # | Description | Type | Status |
-|---|-------------|------|--------|
-| 1 | Bubble Tea TUI implementation | Feature | Partial |
-| 2 | Pause / Resume / Next track support | Feature | Done |
-| 3 | Volume control | Feature | Not Planned |
-| 4 | Custom media directory / system-wide media scanning | Feature | Partial |
-| 5 | Headphone wear detection (auto-pause on removal) | Feature | Research |
-| 6 | Sample rate mismatch on some tracks | Bug | Known/Fixed |
-| 7 | CI/CD — GitHub Actions for running tests and building release executables | Feature | Planned |
-| 8 | Album / playlist support | Feature | Planned |
-| 9 | Artist fetching (background job) | Feature | Planned |
-| 10 | Play songs from external sources (YouTube) | Feature | Done |
+1. Run the app against the local `Media/` folder.
+2. Learn how `main`, `library`, `tui`, `player`, and `decoder` fit together.
+3. Pick a small test, bug, or focused UI issue.
+4. Open a first pull request without needing private project context.
 
+## Current Status
 
+### Working Today
 
-## Usage
+- Bubble Tea TUI for browsing and playing a local music library.
+- Audio playback through `beep` for `.mp3`, `.flac`, `.wav`, and `.ogg`.
+- FFmpeg-backed support for additional audio formats such as `.m4a`, `.aac`, and `.opus` when FFmpeg is installed.
+- Fast startup from the local `Media/` folder, followed by background scanning of other library directories.
+- Live local filtering with an explicit search mode opened by `q` or `?`.
+- Random next-track mode toggled with `Ctrl+R`.
+- External video handoff for `.mp4` files through `ffplay`.
+- Go test coverage across the core packages plus GitHub Actions for CI and releases.
+
+### Still Evolving
+
+- Online, radio, and external-search flows are actively evolving and should not be treated as the default contributor path.
+- If something in the contributor flow is unclear, open a regular issue and describe the gap in context.
+
+## Quick Start
+
+### Requirements
+
+- Go `1.25.5` or newer.
+- FFmpeg if you want extended audio-format support and external `.mp4` playback through `ffplay`.
+- Local media files in the repository `Media/` folder if you want immediate content on startup.
+- Internet access on the first run may be needed so the app can resolve or install its `yt-dlp` helper binary.
+
+### Run The Full Test Suite
+
+```bash
+go test ./...
+```
+
+Note: the full local suite includes `yt_dlp` integration-style tests, so it may require internet access and external tooling on your machine.
+
+### Start The App
+
 ```bash
 go run .
 ```
 
-or build and run the executable:
+You can also build the binary first:
+
 ```bash
 go build
 ./playmusic
 ```
 
-Drop your media files into the `Media` directory and they will be played in order.
-Player will also search for the music in common places in your PC and will add them to the playlist.
+On Windows the binary name will be `playmusic.exe`.
 
-## Hotkeys
+## Controls
 
-- `up/down` - navigate list
-- `space` - pause/resume
-- `enter` in list focus - play selected track
-- `q` or `?` - enter search focus
-- `enter` in search focus - apply the local filter and return to list focus
-- `esc` in search focus - clear query and return to list focus
+| Key | Action |
+| --- | --- |
+| `Up` / `Down` | Move through the list |
+| `Enter` | Play the selected track |
+| `Space` | Pause or resume audio playback |
+| `q` or `?` | Enter search mode |
+| `Enter` in search mode | Keep the current filter and return to list mode |
+| `Esc` in search mode | Clear the filter and return to list mode |
+| `Ctrl+R` | Toggle random next-track mode |
+| `Ctrl+Q` or `Ctrl+C` | Quit |
 
-## Requirements
+For `.mp4` files, PlayMusic hands playback to `ffplay`, so playback controls happen in the external player instead of inside the TUI.
 
-- Go 1.21 or later
-- FFmpeg (optional) — install and add to PATH for extended format support. For Windows all can be done by running command: winget install ffmpeg. 
-- yt-dlp will be installed to the temporary directory on your PC and will be used for the search and stream music feature.
+## Project Map
+
+- [docs/onboarding.md](docs/onboarding.md): guided path from clone to first PR in 30-60 minutes.
+- [docs/workflow.md](docs/workflow.md): how to choose a task, keep scope small, and know what "done" means.
+- [docs/architecture.md](docs/architecture.md): package map and main application flows.
+- [docs/testing.md](docs/testing.md): local testing, CI expectations, and manual verification tips.
+
+## Community
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- [SUPPORT.md](SUPPORT.md)
+- [SECURITY.md](SECURITY.md)
+- [LICENSE](LICENSE)
+
+## Known Notes For Contributors
+
+- The primary contributor path is local library playback and TUI behavior.
+- The current GitHub Actions PR workflow excludes the `yt_dlp` package, so local `go test ./...` remains the best pre-PR verification command.
+- `config.go` contains path-resolution helpers that are not yet wired into the current `main.go` flow, so do not document them as a supported user-facing configuration system.
 
 ## Attribution
-Music used in demo:
->'Shadows and Dust' by Scott Buckley – released under CC-BY 4.0. www.scottbuckley.com.au
->'Rites of passage' by Scott Buckley – released under CC-BY 4.0. www.scottbuckley.com.au
 
-
-
-## Concurrency
-
-The player uses goroutines and channels to manage concurrent operations and user input
-
-### WaitGroup() - do many things at once and wait for them ALL to finish before continuing.
-
-Used in library package to probe all track durations concurrently, improving startup time significantly when the number of tracks is large. 
-Without this the durations would be probed sequentially, in which time would scale linearly with the number of tracks.
-
-Visual example of the concept:
-
-```
-|-main: [wg.Wait()... blocking until all done...]
-|-goroutine 1: [ProbeDuration(track1)...]
-|-goroutine 2: [ProbeDuration(track2)...]
-|-goroutine 3: [ProbeDuration(track3)...]
-```
-
-### Non-blocking user input handling with goroutines
-
-Used for input handling in main.go while tracks are playing.
-Without a goroutine, main thread could either play music OR handle user input, not both.
-
-```go
-go handleInput(player) // runs independently in the background while main thread continues to play music
-
-for _, track := range tracks {
-    player.Play(track) 
-    player.Wait() // unblocks next track when song naturally finishes OR when user presses a key to skip 
-}
-```
-
-### Bubbletea event loop (main goroutine)
-
-`Update(), View()` Handles messages and updates the view
-
-`Player goroutine` Plays music
-
-`tea.Cmd goroutine` Searcher.Search() blocks here, not in main loop 
-
-
-### Ideal approach on startup
-
-1. LoadLibrary("Media") - blocking 
-2. Start TUI with immediate local tracks
-3. `go ScanSystem()` background job, sends new tracks to TUI via channels
-    * `newTrackMsg` everytime new track was found 
-    * TUI appends it to the list
-
-    
+Demo music in the repository is attributed in the existing project materials and should remain credited when reused for demos.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ The project is meant to be useful in two ways:
 
 Project language is English for repository docs, issues, pull requests, and other contributor-facing materials.
 
+## Related Application
+
+This repository is the CLI/TUI version of PlayMusic. It runs in the terminal and is focused on local playback, keyboard-driven navigation, and Go contributor practice.
+
+The related desktop application lives at [samuaks/musical-palm-tree](https://github.com/samuaks/musical-palm-tree). That project opens in a separate native window and is built with Tauri, React, and Rust. Use that repository for GUI application work such as the windowed library view, waveform player UI, video viewport, desktop packaging, and Tauri-specific behavior.
+
+For a longer comparison, read [docs/related-projects.md](docs/related-projects.md).
+
+When opening an issue or pull request, choose the repository based on the user surface:
+
+- terminal behavior, Go packages, CLI/TUI controls, or this contributor workflow: use this repository;
+- desktop window behavior, React UI, Rust/Tauri scanner or waveform code, or native app packaging: use `samuaks/musical-palm-tree`.
+
 ## Start Here
 
 - Want to run the app quickly? Start with [Quick Start](#quick-start).
@@ -93,6 +106,7 @@ For `.mp4` files, PlayMusic hands playback to `ffplay`, so playback controls hap
 - [docs/workflow.md](docs/workflow.md): how to choose a task, keep scope small, and know what "done" means.
 - [docs/architecture.md](docs/architecture.md): package map and main application flows.
 - [docs/testing.md](docs/testing.md): local testing, CI expectations, and manual verification tips.
+- [docs/related-projects.md](docs/related-projects.md): how this CLI/TUI repository relates to the separate desktop application.
 
 ## Community
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting A Security Issue
+
+Please do not publish full exploit details in a public issue.
+
+Current temporary process:
+
+1. Open a minimal GitHub issue or contact a maintainer and state that you found a possible security problem.
+2. Do not include sensitive details, credentials, or a full exploit in that first public message.
+3. Ask for a private follow-up channel if one is needed.
+
+This is a temporary policy until the project publishes a dedicated private reporting path.
+
+## What To Include
+
+When you report a security problem, include:
+
+- affected area or package;
+- impact;
+- supported versions or commit range if known;
+- reproduction steps that can be shared safely;
+- whether the issue is already being exploited in practice, if known.
+
+## What Not To Post Publicly
+
+- secrets or tokens;
+- private file paths that expose personal data;
+- full proof-of-concept exploit details before maintainer review;
+- anything that would make exploitation easier before a fix exists.
+
+## Response Target
+
+The project aims to acknowledge security reports within 5 working days.
+
+## Scope
+
+Use this policy for vulnerabilities or abuse paths that could affect confidentiality, integrity, or availability.
+
+Regular bugs, crashes, and usability issues should go through the standard support flow in [SUPPORT.md](SUPPORT.md).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,58 @@
+# Support
+
+## Where To Ask For Help
+
+At the moment, the official support path for PlayMusic is GitHub-first.
+
+- Use GitHub issues for bugs, task proposals, and contributor-flow questions.
+- Use pull request comments for implementation-specific questions on an active change.
+- If a future Discord or Notion space becomes part of the contributor flow, this file should be updated to link it.
+
+## Which Channel To Use
+
+- Bug report: open a bug issue.
+- Feature or improvement proposal: open a task or enhancement issue.
+- Contributor-flow gap or unclear project information: open a regular issue with the missing context.
+- Question about your current PR: comment in the PR.
+- Security concern: follow [SECURITY.md](SECURITY.md).
+
+## Response Expectations
+
+These are targets, not guarantees:
+
+- first response on new issues: within 3 working days;
+- first review pass on small PRs: within 5 working days;
+- clarification on blocked student-first tasks: as soon as a maintainer is available.
+
+If a task is time-sensitive for onboarding or coursework, say that clearly in the issue or PR.
+
+## How To Ask A Good Question
+
+Good questions usually include:
+
+- what you are trying to do;
+- what file, issue, or command you are working with;
+- what you expected to happen;
+- what actually happened;
+- what you already tried.
+
+Example:
+
+```text
+I am working on issue #123 in tui/update.go.
+I expected Enter in search mode to keep the filter and return to list mode.
+Instead the filter resets after Esc.
+I ran go test ./tui and checked the focus-related tests, but I am not sure where the state reset should live.
+```
+
+## Project Language
+
+English is the project language for repository docs, issues, pull requests, and contributor support requests.
+
+## If You Are Completely New
+
+Start here:
+
+1. [README.md](README.md)
+2. [docs/onboarding.md](docs/onboarding.md)
+3. [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,130 @@
+# Architecture Overview
+
+## Purpose
+
+This document explains the current architecture of PlayMusic in a way that helps a new contributor navigate the codebase quickly.
+
+## The Short Version
+
+PlayMusic is a Go application with a Bubble Tea TUI on top of a local media library and playback layer.
+
+The default user path today is:
+
+```text
+main.go
+  -> load local Media/ synchronously
+  -> start background scan for more library roots
+  -> start Bubble Tea TUI
+  -> select a track
+  -> player + decoder handle playback
+```
+
+## Package Map
+
+| Package | Responsibility |
+| --- | --- |
+| `main` | Startup flow and wiring |
+| `library` | Track discovery, enrichment, deduplication, scan events |
+| `tui` | Application state, keyboard handling, rendering, scan-status updates |
+| `player` | Playback lifecycle, pause/resume/next, external video handoff |
+| `decoder` | Native decoding through `beep`, FFmpeg-backed decode paths, stream decode helpers |
+| `ffmpeg` | FFmpeg adapter functions and probing helpers |
+| `search` | Search abstractions and sources used by evolving external-search flows |
+| `yt_dlp` | `yt-dlp` integration helpers used by external media flows |
+| `helpers` | Shared helper functions such as duration formatting |
+| `colors` | Styling constants used by the UI |
+
+## Core Data Shape
+
+The main shared data structure is `library.Track`.
+
+It carries:
+
+- identity such as `Path` or `YTVideoURl`;
+- display fields such as `Trackname`, `Artist`, and `Title`;
+- metadata such as `Duration`, `Album`, `Year`, and `Genre`.
+
+If you are trying to understand how data moves through the app, start with this type.
+
+## Startup Flow
+
+The real startup path lives in `main.go`.
+
+Today it does this:
+
+1. installs or resolves the `yt-dlp` binary;
+2. loads the local `Media/` directory synchronously;
+3. starts a background scan for additional library directories;
+4. passes the initial tracks and scan channel into the TUI model;
+5. runs the Bubble Tea program.
+
+This means the app is optimized to show something quickly instead of waiting for a full library scan.
+
+## Local Library Flow
+
+`library/library.go` handles the initial load.
+
+Important ideas:
+
+- `LoadLibrary("Media")` is the fast startup path;
+- `DefaultLibraryDirs()` defines the broader library roots;
+- `BackgroundLibraryDirs()` excludes `Media/` so startup does not duplicate work;
+- deduplication tries to prevent duplicate tracks across startup and background scans.
+
+## Background Scan Flow
+
+`library/scan.go` emits `ScanEvent` values over a channel.
+
+The TUI listens for:
+
+- discovered tracks;
+- enriched tracks;
+- non-fatal scan errors;
+- scan completion.
+
+This lets the UI stay responsive while the rest of the library is still being discovered.
+
+## Playback Flow
+
+`player/player.go` owns playback state.
+
+For audio files:
+
+1. `player.Play()` asks `decoder.Decode()` for a streamer;
+2. `decoder` chooses a native `beep` decoder or an FFmpeg-backed path;
+3. `player` sends the streamer to `speaker`;
+4. `Wait()`, `Pause()`, `Resume()`, and `Next()` control playback lifecycle.
+
+For `.mp4` files:
+
+- PlayMusic does not render video inside the TUI;
+- it hands playback off to `ffplay` through `player.playVideo()`.
+
+## TUI Flow
+
+The TUI lives mostly in:
+
+- `tui/model.go`
+- `tui/update.go`
+- `tui/view.go`
+
+Key ideas:
+
+- the model keeps track list, selected/current index, elapsed time, focus mode, and scan state;
+- the UI has two explicit focus modes: list and search;
+- background scan events update the model incrementally;
+- the player bar and search bar reflect current state instead of driving business logic.
+
+## Where To Start Based On The Change
+
+- Startup or scan roots: `main.go`, `library/library.go`, `library/scan.go`
+- Track metadata or dedup: `library/*`
+- Keyboard behavior or layout: `tui/*`
+- Audio or video playback: `player/player.go`, `decoder/decoder.go`, `ffmpeg/*`
+- External-search plumbing: `search/*`, `yt_dlp/*`
+
+## Areas To Treat As Experimental
+
+The default contributor path is local library plus TUI plus playback.
+
+External-search, radio, and online-flow code exists in the repository history and supporting packages, but those areas are still evolving and should be documented carefully.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,114 @@
+# Onboarding
+
+## Why Read This
+
+This guide is for a new contributor who wants to go from clone to first pull request in about 30-60 minutes.
+
+You do not need deep Go or open-source experience to get value from this project.
+
+## Outcome
+
+By the end of this guide, you should be able to:
+
+- run the project locally;
+- understand the main files worth reading first;
+- choose a small, realistic task;
+- open a first PR with the right level of scope.
+
+## Step 1: Clone And Verify
+
+Run the basic checks first:
+
+```bash
+go test ./...
+go run .
+```
+
+If the app starts, you already have a working local environment.
+
+Two practical notes:
+
+- the app may need internet access on first run so it can resolve or install `yt-dlp`;
+- the full test suite includes `yt_dlp` integration-style tests, so offline environments may need extra care.
+
+## Step 2: Put Something In `Media/`
+
+The default startup flow loads the local `Media/` directory first.
+
+- Put one or more audio files into `Media/`.
+- Start the app again if needed.
+- Confirm that you can see the track list and play a file.
+
+## Step 3: Learn The Five Files That Explain The Project
+
+Read these files in order:
+
+| File | Why it matters |
+| --- | --- |
+| `main.go` | Shows the real startup flow and what the default app path is today |
+| `library/library.go` | Explains local library loading and default scan roots |
+| `library/scan.go` | Explains background scan events and incremental updates |
+| `tui/model.go` and `tui/update.go` | Explain the UI state and keyboard behavior |
+| `player/player.go` | Explains playback lifecycle, pause/resume, and `.mp4` handoff |
+
+If you want one extra file after that, read `decoder/decoder.go`.
+
+## Step 4: Pick A Beginner-Friendly Task
+
+Good first tasks are usually:
+
+- a focused test addition;
+- a small TUI text or UX fix;
+- a narrow bug with clear reproduction;
+- an issue rewrite that adds context and acceptance criteria.
+
+If labels are incomplete or inconsistent, use common sense:
+
+- prefer one-package changes;
+- avoid vague refactors;
+- ask in the issue before taking on something large.
+
+## Step 5: Keep Scope Intentionally Small
+
+A strong first PR usually changes one of these:
+
+- one test file;
+- one behavior inside one package;
+- one user-facing string or help message.
+
+You do not need to "prove yourself" with a large change.
+
+## Step 6: Open The PR
+
+Before opening the PR:
+
+```bash
+go test ./...
+```
+
+Then explain:
+
+- what you changed;
+- why it matters;
+- how you verified it;
+- what you deliberately did not change.
+
+Use [CONTRIBUTING.md](../CONTRIBUTING.md) and the PR template for the detailed workflow.
+
+## If You Get Stuck
+
+- Ask in the issue if the task scope is still unclear.
+- Ask in the PR if you already started work.
+- Use [SUPPORT.md](../SUPPORT.md) when you need the right channel or response expectations.
+
+## Suggested First-Week Ladder
+
+Try to move through tasks like this:
+
+1. issue cleanup
+2. focused test
+3. small TUI fix
+4. small bug fix
+5. one-package feature improvement
+
+That progression gives you context without making your first week stressful.

--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -1,0 +1,40 @@
+# Related PlayMusic Projects
+
+PlayMusic currently has two related repositories with different user surfaces.
+
+## CLI/TUI
+
+Repository: [samuaks/playmusic](https://github.com/samuaks/playmusic)
+
+This repository is the terminal version of PlayMusic. It is written in Go and focuses on:
+
+- local media library loading and scanning;
+- terminal keyboard controls;
+- Bubble Tea TUI behavior;
+- playback through Go packages and external helpers;
+- beginner-friendly Go contribution practice.
+
+Open issues and pull requests here when the change affects terminal behavior, Go packages, CLI testing, or this contributor workflow.
+
+## Desktop Application
+
+Repository: [samuaks/musical-palm-tree](https://github.com/samuaks/musical-palm-tree)
+
+This is the separate desktop application. It opens in a native window and is built with Tauri, React, and Rust. It focuses on:
+
+- windowed library browsing;
+- React UI and desktop interaction;
+- waveform player UI;
+- video playback viewport;
+- Tauri IPC between the frontend and Rust backend;
+- native desktop builds and packaging.
+
+Open issues and pull requests there when the change affects the windowed application experience, React components, Tauri commands, Rust scanner or waveform code, or desktop packaging.
+
+## Choosing The Right Repository
+
+If the behavior happens in the terminal, use `samuaks/playmusic`.
+
+If the behavior happens in a separate desktop window, use `samuaks/musical-palm-tree`.
+
+If a task says "application part" or "app window", confirm whether it refers to the desktop application before starting implementation in this repository.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,16 @@ go test ./...
 
 This is the recommended default before opening a pull request.
 
+For verbose output, use `-v`:
+
+```bash
+go test -v ./...
+go test -v ./library
+go test -run TestName -v ./tui
+```
+
+Verbose output is useful when you want to see each test name, investigate a failing package, or include clearer verification notes in a pull request.
+
 Important: the full local suite includes `yt_dlp` integration-style tests. Those tests may require internet access and the ability to install or run external tooling.
 
 ## Also Run The App

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,94 @@
+# Testing Guide
+
+## Goal
+
+This guide explains what to run locally before a PR and how local verification differs from the current GitHub Actions setup.
+
+## Default Local Check
+
+Run the full local test suite:
+
+```bash
+go test ./...
+```
+
+This is the recommended default before opening a pull request.
+
+Important: the full local suite includes `yt_dlp` integration-style tests. Those tests may require internet access and the ability to install or run external tooling.
+
+## Also Run The App
+
+For behavior changes, also run:
+
+```bash
+go run .
+```
+
+Manual verification matters for TUI and playback changes.
+
+## Package-Level Test Expectations
+
+| Package area | Typical coverage |
+| --- | --- |
+| `library` | loading, deduplication, background scanning, enrichment pipeline |
+| `tui` | model updates, focus changes, list behavior, scan event handling |
+| `player` | playback lifecycle, stopping, pause/resume, external video handoff |
+| `decoder` and `ffmpeg` | decoder selection and FFmpeg probing helpers |
+| `yt_dlp` | integration-oriented helpers around external tooling |
+
+## CI vs Local
+
+Current GitHub Actions behavior on pull requests:
+
+- installs ALSA-related dependencies on Ubuntu;
+- runs Go tests for most packages;
+- currently excludes the `yt_dlp` package from the PR workflow.
+
+That means:
+
+- local `go test ./...` is still the most complete default command;
+- if you change `yt_dlp`, you should run the relevant tests locally and mention the result in your PR.
+- if you are offline or in a restricted environment, explain which subset you ran and why.
+
+## Manual Checks Worth Doing
+
+If your change affects behavior, try to verify the specific path directly:
+
+- local audio playback from `Media/`;
+- entering and leaving search mode;
+- filter behavior while typing;
+- background scan status updates;
+- pause/resume and next-track behavior;
+- random mode via `Ctrl+R`;
+- `.mp4` handoff if you changed video-related behavior and have `ffplay`.
+
+## When To Add Tests
+
+Add or update tests when:
+
+- you fix a bug with a reliable reproduction path;
+- you change branching logic in `library`, `tui`, or `player`;
+- you change startup or scan behavior;
+- a regression would be easy to miss manually.
+
+## When Manual-Only Verification Is Acceptable
+
+Manual-only verification can be acceptable for:
+
+- pure copy-only or metadata-only changes;
+- small visual/help-text changes;
+- exploratory work that is hard to test immediately.
+
+If you skip tests, say so explicitly in the PR.
+
+## If A Test Is Environment-Sensitive
+
+Document the limitation instead of hiding it.
+
+Good example:
+
+```text
+I ran go test ./...
+The change touches yt_dlp behavior, so I also ran the package tests locally on Windows.
+CI currently does not cover that package in the PR workflow.
+```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,130 @@
+# Contributor Workflow
+
+## Purpose
+
+This guide explains how to choose a task, keep the scope healthy, and know what "done" means in PlayMusic.
+
+## How To Choose A Task
+
+Pick work that is:
+
+- understandable from the issue alone, or after one short clarification;
+- limited to one package or one clear user flow;
+- easy to verify with a test or a short manual check.
+
+Strong first choices:
+
+- `good first issue`
+- small `bug`
+- focused `enhancement`
+
+If labels are missing, look for issues with:
+
+- a clear problem statement;
+- concrete acceptance criteria;
+- hints about which files to read first.
+
+## Suggested Difficulty Scale
+
+| Level | Typical scope | Typical time |
+| --- | --- | --- |
+| `easy` | tests, copy, one small behavior fix | 30 min to 2 h |
+| `medium` | one-package logic change with tests | half day to 1 day |
+| `hard` | cross-package behavior, concurrency, release, or architecture work | more than 1 day |
+
+## What A Good Issue Should Contain
+
+A contributor-friendly issue should include:
+
+- a short, descriptive title that still reads well when GitHub turns it into a branch name;
+- context: why the work matters;
+- problem statement: what is wrong today;
+- scope: what is in and out;
+- acceptance criteria: how we know it is done;
+- starting points: files or packages to read first;
+- level and rough time estimate.
+
+If an issue is missing these pieces, improving the issue first is a valid contribution.
+
+## How To Open A Good Issue
+
+Use GitHub issues as the starting point for implementation work.
+
+Recommended flow:
+
+1. search existing issues first so you do not create a duplicate;
+2. choose the right template:
+   `Bug report` for broken behavior or `Development task` for planned work;
+3. write one issue for one concrete problem or outcome;
+4. keep the title short and specific;
+5. fill the body so someone outside the core team could understand the task;
+6. once the issue is ready, use `Create a branch` from that issue.
+
+The issue should be good enough that another contributor could pick it up later without needing hidden context.
+
+## Definition Of Done
+
+A task is usually done when:
+
+- the intended behavior works;
+- relevant tests pass, or the missing coverage is explained honestly;
+- user-facing changes have matching docs or help text updates;
+- the PR explains verification steps;
+- the change stays within the agreed scope;
+- known limitations are called out instead of hidden.
+
+## Good First Contribution Examples
+
+- add a regression test in `library` for scan or dedup logic;
+- improve a small `tui` help string or status message;
+- fix a narrow playback state bug with a reliable reproduction path;
+- rewrite a vague issue using the project template.
+
+## Usually Not A First Contribution
+
+- major refactors with no user-facing acceptance criteria;
+- release or workflow changes without maintainer agreement;
+- experimental online or radio flows that are still moving quickly;
+- cross-package concurrency changes unless the issue is tightly scoped.
+
+## Preferred Task Flow
+
+1. Confirm the issue still matches the current code.
+2. Use `Create a branch` from the GitHub issue so the work stays linked to that task.
+3. Make the smallest change that solves the stated problem.
+4. Verify it locally.
+5. Open a PR with a short summary and verification notes.
+
+## Issue Title Guidance
+
+Since branches are created from issues in the current workflow, issue titles should be clean and specific.
+
+Prefer titles that:
+
+- describe one concrete problem or outcome;
+- avoid vague words like `stuff`, `cleanup`, or `refactor` on their own;
+- stay short enough to read in lists and pull request references.
+
+Good examples:
+
+- `Fix panic when pausing during radio track switch`
+- `Show clearer empty-library message on startup`
+- `Keep selected track when background scan finishes`
+
+Weak examples:
+
+- `Bug in player`
+- `TUI issue`
+- `Refactor code`
+
+## If The Task Is Bigger Than Expected
+
+Do not force the original scope.
+
+Instead:
+
+- stop and describe what you learned;
+- split the task into smaller follow-ups;
+- ask for scope confirmation before continuing.
+
+That is good collaboration, not failure.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -24,6 +24,8 @@ If labels are missing, look for issues with:
 - concrete acceptance criteria;
 - hints about which files to read first.
 
+If those details are missing, improving the issue before coding is useful work. Add context, scope, acceptance criteria, and starting points so another contributor could pick it up later.
+
 ## Suggested Difficulty Scale
 
 | Level | Typical scope | Typical time |
@@ -31,6 +33,20 @@ If labels are missing, look for issues with:
 | `easy` | tests, copy, one small behavior fix | 30 min to 2 h |
 | `medium` | one-package logic change with tests | half day to 1 day |
 | `hard` | cross-package behavior, concurrency, release, or architecture work | more than 1 day |
+
+## Suggested Story Points
+
+Story points are rough size hints, not deadlines.
+
+| Points | Typical meaning |
+| --- | --- |
+| `1` | docs, copy, one focused test, or a tiny behavior fix |
+| `2` | small one-package change with clear verification |
+| `3` | one-package behavior change with tests and manual checking |
+| `5` | larger work with several files or uncertain edge cases |
+| `8` | too large for a first contribution; split before starting |
+
+For first-time contributors, prefer `1`, `2`, or a very clear `3`.
 
 ## What A Good Issue Should Contain
 


### PR DESCRIPTION
## Summary

This PR adds a documentation baseline for the PlayMusic repository.

It introduces and updates:

- repository-level contributor docs: `README.md`, `CONTRIBUTING.md`, `SUPPORT.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, and `LICENSE`;
- GitHub contribution helpers: issue templates and pull request template;
- contributor guides under `docs/`:
  - onboarding guide for first-time contributors;
  - workflow guide for choosing and scoping tasks;
  - testing guide with local/CI expectations;
  - architecture overview;
  - related-projects guide for the CLI/TUI repo and the separate desktop app;
- clearer guidance for good first issues, issue-first workflow, fork workflow, story-point estimates, verbose test commands, and commit messages.

## Why

The project is meant to be beginner-friendly, so contributors need enough public context to choose a task, understand the current app shape, verify changes locally, and open useful issues/PRs without relying on private explanations.

This also clarifies the split between:

- this repository: Go CLI/TUI PlayMusic;
- `samuaks/musical-palm-tree`: separate Tauri/React/Rust desktop application.

## Verification

- [x] Documentation reviewed for consistency across README, CONTRIBUTING, and `docs/`
- [x] `git diff --check`
- [ ] `go test ./...`

Not run: Go tests were skipped because this PR only changes documentation and GitHub templates.

## Scope

This PR does not change application behavior.

Out of scope:

- GitHub label configuration;
- application code changes;
- radio/online feature stabilization;
- desktop app implementation changes.

